### PR TITLE
Add table name configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ class BeforeHandler implements BeforeHandlerInterface
 ```
 
 ### Retrieving logged entries
-All events will be logged in the `activity_log`-table. This package provides an Eloquent model to work with the table. You can use all the normal Eloquent methods that you know and love. Here's how you can get the last 100 activities together with the associated users.
+All events will be logged in the `activity_log`-table by default or the table name specified in the config file. This package provides an Eloquent model to work with the table. You can use all the normal Eloquent methods that you know and love. Here's how you can get the last 100 activities together with the associated users.
 
 ```php
 use Spatie\Activitylog\Models\Activity;

--- a/src/Spatie/Activitylog/Models/Activity.php
+++ b/src/Spatie/Activitylog/Models/Activity.php
@@ -8,12 +8,18 @@ use Exception;
 
 class Activity extends Eloquent
 {
+
     /**
-     * The database table used by the model.
+     * Create a new Eloquent model instance.
      *
-     * @var string
+     * @param array $attributes
      */
-    protected $table = 'activity_log';
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+
+        $this->setTable(config('activitylog.tableName', 'activity_log'));
+    }
 
     /**
      * Get the user that the activity belongs to.

--- a/src/config/activitylog.php
+++ b/src/config/activitylog.php
@@ -57,4 +57,14 @@ return [
     |
     */
     'userModel' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | The database table name where the logs are stored
+    |--------------------------------------------------------------------------
+    |
+    | This is the name of the database table where the logs are stored.
+    |
+    */
+    'tableName' => 'activity_log',
 ];

--- a/src/migrations/create_activity_log_table.stub
+++ b/src/migrations/create_activity_log_table.stub
@@ -10,7 +10,7 @@ class CreateActivityLogTable extends Migration
      */
     public function up()
     {
-        Schema::create('activity_log', function (Blueprint $table) {
+        Schema::create(config('activitylog.tableName', 'activity_log'), function (Blueprint $table) {
             $table->increments('id');
             $table->integer('user_id')->nullable();
             $table->string('text');
@@ -24,6 +24,6 @@ class CreateActivityLogTable extends Migration
      */
     public function down()
     {
-        Schema::drop('activity_log');
+        Schema::drop(config('activitylog.tableName', 'activity_log'));
     }
 }


### PR DESCRIPTION
Added a table name option to the configuration file as discussed in #13. The table name defaults to activity_log when the packages config file is not published.