### PR TITLE
Use user identifier accessors if applicable

### DIFF
--- a/src/Spatie/Activitylog/ActivitylogSupervisor.php
+++ b/src/Spatie/Activitylog/ActivitylogSupervisor.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Activitylog;
 
+use Eloquent;
 use Illuminate\Config\Repository;
 use Illuminate\Contracts\Auth\Guard;
 use Spatie\Activitylog\Handlers\BeforeHandler;
@@ -92,13 +93,17 @@ class ActivitylogSupervisor
         if (is_numeric($userId)) {
             return $userId;
         }
+        
+        if ($userId instanceof Eloquent) {
+            return $userId->getKey();
+        }
 
         if (is_object($userId)) {
             return $userId->id;
         }
 
         if ($this->auth->check()) {
-            return $this->auth->user()->id;
+            return $this->auth->user()->getAuthIdentifier();
         }
 
         if (is_numeric($this->config->get('activitylog.defaultUserId'))) {


### PR DESCRIPTION
This is more robust (tests are not updated).

Also, you should really update the dependencies in `composer.json`, as the package is using components of `illuminate/config` and `illuminate/database`. Moreover, the package assumes that Laravel's shipped default aliases are still present (e.g. `Eloquent`, `Config`, `Log`). IMHO packages are better off to use the Facade directly.